### PR TITLE
Make demo work out of the box

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,12 +7,12 @@
   ],
   "devDependencies": {
     "web-component-tester": "~2.2.6",
-    "test-fixture": "polymer/test-fixture#~0.1.0",
+    "test-fixture": "polymer/test-fixture",
     "webcomponentsjs": "webcomponents/webcomponentsjs#~0.5.5",
     "quick-element": "polymer/quick-element"
   },
   "dependencies": {
-    "polymer": "polymer/polymer#0.8-preview",
+    "polymer": "polymer/polymer",
     "paper-shadow": "polymer/paper-shadow#0.8-preview"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "quick-element": "polymer/quick-element"
   },
   "dependencies": {
-    "polymer": "polymer/polymer#0.8",
+    "polymer": "polymer/polymer#0.8-rc2",
     "paper-shadow": "polymer/paper-shadow#0.8-preview",
     "paper-card": "polymer/paper-card"
   }

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,8 @@
     "quick-element": "polymer/quick-element"
   },
   "dependencies": {
-    "polymer": "polymer/polymer",
-    "paper-shadow": "polymer/paper-shadow#0.8-preview"
+    "polymer": "polymer/polymer#0.8",
+    "paper-shadow": "polymer/paper-shadow#0.8-preview",
+    "paper-card": "polymer/paper-card"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -15,11 +15,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
 
-  <script src="../../webcomponentsjs/webcomponents.js"></script>
-  <link href="../../font-roboto/roboto.html" rel="import">
-  <link href="../../layout/layout.html" rel="import">
-  <link href="../../quick-element/quick-element.html" rel="import">
-  <link href="../paper-card.html" rel="import">
+  <script src="../bower_components/webcomponentsjs/webcomponents.js"></script>
+  <link href='//fonts.googleapis.com/css?family=RobotoDraft:regular,bold,italic,thin,light,bolditalic,black,medium&amp;lang=en' rel='stylesheet' type='text/css'>
+  <link href="../bower_components/layout/layout.html" rel="import">
+  <link href="../bower_components/quick-element/quick-element.html" rel="import">
+  <link href="../bower_components/paper-card/paper-card.html" rel="import">
 
   <style>
     body {
@@ -34,6 +34,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 </head>
 <body>
+
   <template is="quick-element" name="paper-card-demo">
     <style> 
       section {


### PR DESCRIPTION
This makes the demo work out of the box without having Polymer checked out to a sibling directory of paper-card. Please refer to https://github.com/Polymer/quick-element/pull/3 for further details on the workaround.
