### PR TITLE
set paper-card property user-select to none

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -52,6 +52,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         margin: 16px;
         padding: 16px;
         border-radius: 2px;
+
+        -webkit-touch-callout: none;
+        -webkit-user-select: none;
+        -khtml-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
       }
 
       .fab {


### PR DESCRIPTION
Double clicking on paper-card elements triggered text selection:

![screen shot paper-card text-selection](https://cloud.githubusercontent.com/assets/473924/7035018/00547a38-dd85-11e4-9af0-e642a5ede3a4.png)
